### PR TITLE
analyze-frameworks: added windows support. ignore vendor/ dir

### DIFF
--- a/code/15-framework-functions/analyze-frameworks.php
+++ b/code/15-framework-functions/analyze-frameworks.php
@@ -60,7 +60,6 @@ foreach ($frameworks as $framework) {
             continue;
         }
 
-        var_dump($realpath);
         $contents = file_get_contents($realpath);
         try {
             $ast = $parser->parse($contents);

--- a/code/15-framework-functions/analyze-frameworks.php
+++ b/code/15-framework-functions/analyze-frameworks.php
@@ -50,20 +50,24 @@ foreach ($frameworks as $framework) {
     });
 
     foreach ($frameworkFilesIterator as $file) {
+        $realpath = str_replace('\\', '/', $file->getRealPath());
         if (
-            false !== strpos($file->getRealPath(), '/Tests/')
-            || false !== strpos($file->getRealPath(), '/tests/')
+            false !== strpos($realpath, '/Tests/')
+            || false !== strpos($realpath, '/tests/')
+            || false !== strpos($realpath, '/vendor/')
+            || false !== strpos($realpath, '/vendor-bin/')
         ) {
             continue;
         }
 
-        $contents = file_get_contents($file->getRealPath());
+        var_dump($realpath);
+        $contents = file_get_contents($realpath);
         try {
             $ast = $parser->parse($contents);
             $traverser->traverse($ast);
         } catch (Error $error) {
             trigger_error(
-                "Could not parse '{$file->getRealPath()}'.",
+                "Could not parse '{$realpath}'.",
                 E_USER_WARNING
             );
             continue;


### PR DESCRIPTION
this PR adds a normalization step, to make the path-blacklist also work on windows.

additionally the composer-standard `vendor/` and `vendor-bin` directories will be added to the default-ignore list